### PR TITLE
patch: Do not output on success

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,13 +68,11 @@ func main() {
 	}
 
 	if flags.dry == false {
-		resolve := output.Stdout("Attempting to push new tag to GitHub...")
+		output.Stdout("Attempting to push new tag to GitHub...")
 		err = tagOutlet.PushTag(tag)
 		if err != nil {
-			resolve.Failure()
 			output.Fatal(err)
 		}
-		resolve.Success()
 	}
 }
 

--- a/output/output.go
+++ b/output/output.go
@@ -7,39 +7,14 @@ import (
 
 var PrintToStdout = true
 
-// Resolver defines an interface for marking a previous output as
-// either failed or succeeded.
-//
-// At the moment, it only operates on the last output.
-type Resolver interface {
-	Success()
-	Failure()
-}
-
-type resolver struct{}
-
-func (r resolver) Success() {
-	fmt.Fprint(os.Stdout, " Success!\n")
-}
-
-func (r resolver) Failure() {
-	fmt.Fprint(os.Stdout, " Failure!\n")
-}
-
-func Stdout(args ...interface{}) resolver {
+func Stdout(args ...interface{}) {
 	if PrintToStdout {
 		fmt.Fprint(os.Stdout, args...)
 	}
-
-	return resolver{}
 }
 
 func StdoutForce(args ...interface{}) {
 	fmt.Fprint(os.Stdout, args...)
-}
-
-func Stderr(args ...interface{}) {
-	fmt.Fprint(os.Stderr, args...)
 }
 
 func Fatal(args ...interface{}) {


### PR DESCRIPTION
Just wanted to merge this to test it out.


If we adhere to a classic unix convention where "no news is good news" I
think using this command in tandem with pushing tagged docker images
could be slightly simpler:
```
tag=$(semantics --output-tag) && docker tag cool-image "cool-image:${tag}" || true
docker push cool-image
```

Before you had to invoke semantics twice (once with `--dry-run` to
output the tag and once to actually push said tag).

Also removed some of the output package since it wasn't being used.
